### PR TITLE
Fix names for Lithium Fluoride and Beryllium Fluoride

### DIFF
--- a/src/Java/gtPlusPlus/core/material/nuclear/FLUORIDES.java
+++ b/src/Java/gtPlusPlus/core/material/nuclear/FLUORIDES.java
@@ -104,7 +104,7 @@ public class FLUORIDES {
 			});
 
 	public static final Material BERYLLIUM_FLUORIDE = new Material(
-			"Beryllium Tetrafluoride", //Material Name
+			"Beryllium Fluoride", //Material Name
 			MaterialState.LIQUID, //State
 			new short[]{120, 180, 120, 0}, //Material Colour
 			Materials.Beryllium.mMeltingPoint, //Melting Point in C
@@ -119,7 +119,7 @@ public class FLUORIDES {
 			});
 
 	public static final Material LITHIUM_FLUORIDE = new Material(
-			"Lithium Tetrafluoride", //Material Name
+			"Lithium Fluoride", //Material Name
 			MaterialState.LIQUID, //State
 			new short[]{225, 220, 255, 0}, //Material Colour
 			Materials.Lithium.mMeltingPoint, //Melting Point in C


### PR DESCRIPTION
'Tetrafluoride' implies a formula with one part metal and four parts fluorine (BeF4, LiF4).
The correct names for BeF2 and LiF are beryllium fluoride and lithium fluoride.