### PR TITLE
Fix for 100% output for the first item

### DIFF
--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialSifter.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialSifter.java
@@ -227,11 +227,7 @@ extends GregtechMeta_MultiBlockBase {
 				this.mMaxProgresstime = Math.max(1, (cloneRecipe.mDuration/5));
 				final ItemStack[] outputs = new ItemStack[cloneRecipe.mOutputs.length];
 				for (int i = 0; i < cloneRecipe.mOutputs.length; i++){
-					if (i==0) {
-						Utils.LOG_WARNING("Adding the default output");
-						outputs[0] =  cloneRecipe.getOutput(i);
-					}
-					else if (this.getBaseMetaTileEntity().getRandomNumber(7500) < cloneRecipe.getOutputChance(i)){
+					if (this.getBaseMetaTileEntity().getRandomNumber(7500) < cloneRecipe.getOutputChance(i)){
 						Utils.LOG_WARNING("Adding a bonus output");
 						outputs[i] = cloneRecipe.getOutput(i);
 					}


### PR DESCRIPTION
This PR fixed the 100% output for the first item in sifter.

First item for gems are Exquisite gems, and drop chances are low.
Could be possible to sort and get 100% dust, but this fixes critical issue with gem sifting