### PR TITLE
Fix NPE issues with Treefarmer and Multitank.

### DIFF
--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntityTreeFarm.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntityTreeFarm.java
@@ -286,6 +286,10 @@ public class GregtechMetaTileEntityTreeFarm extends GT_MetaTileEntity_MultiBlock
 				for (int h = 0; h <= 1; h++) {
 					Utils.LOG_WARNING("Step 4");
 					final IGregTechTileEntity tTileEntity = aBaseMetaTileEntity.getIGregTechTileEntityOffset(xDir + i, h, zDir + j);
+                    if( tTileEntity == null )
+                    {
+                      return false;
+                    }
 					//Farm Floor inner 14x14
 					if (((i != -7) && (i != 7)) && ((j != -7) && (j != 7))) {
 						Utils.LOG_WARNING("Step 5 - H:"+h);

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_MultiTank.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_MultiTank.java
@@ -172,7 +172,7 @@ extends GregtechMeta_MultiBlockBase {
 	public void onPostTick(final IGregTechTileEntity aBaseMetaTileEntity, final long aTick) {
 		super.onPostTick(aBaseMetaTileEntity, aTick);
 
-		if (this.internalStorageTank.amount >= this.maximumFluidStorage){
+		if ((this.internalStorageTank != null) && this.internalStorageTank.amount >= this.maximumFluidStorage){
 			if (this.internalStorageTank.amount > this.maximumFluidStorage){
 				this.internalStorageTank.amount = this.maximumFluidStorage;
 			}


### PR DESCRIPTION
Do not reference fluid stack in multitank when tank has null fluidstack.

Abort treefarmer checkMachine if blocks checked are not GT blocks.