### PR TITLE
 Rewrite and refactor checkRecipe() for several multiblocks, restore machine sounds

### DIFF
--- a/src/Java/gtPlusPlus/core/util/array/ArrayUtils.java
+++ b/src/Java/gtPlusPlus/core/util/array/ArrayUtils.java
@@ -1,6 +1,11 @@
 package gtPlusPlus.core.util.array;
 
+import net.minecraft.item.ItemStack;
+
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 public class ArrayUtils {
 
@@ -15,4 +20,9 @@ public class ArrayUtils {
 		return series;
 	}
 
+	public static ItemStack[] removeNulls(final ItemStack[] v) {
+		List<ItemStack> list = new ArrayList<ItemStack>(Arrays.asList(v));
+		list.removeAll(Collections.singleton((ItemStack)null));
+		return list.toArray(new ItemStack[list.size()]);
+	}
 }

--- a/src/Java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
@@ -199,18 +199,16 @@ GT_MetaTileEntity_MultiBlockBase {
 			return false;
 		}
 
-		// Convert speed bonus to duration multiplier
-		// e.g. 100% speed bonus = 200% speed = 100%/200% = 50% recipe duration.
-		aSpeedBonusPercent = Math.max(-99, aSpeedBonusPercent);
-		float tTimeFactor = 100.0f / (100.0f + aSpeedBonusPercent);
-		this.mMaxProgresstime = (int)(tRecipe.mDuration * tTimeFactor);
-
 		// EU discount
 		float tRecipeEUt = (tRecipe.mEUt * aEUPercent) / 100.0f;
 		float tTotalEUt = 0.0f;
 
+		// Reset outputs and progress stats
 		this.mEUt = 0;
-
+		this.mMaxProgresstime = 0;
+		this.mOutputItems = new ItemStack[]{};
+		this.mOutputFluids = new FluidStack[]{};
+		
 		// Count recipes to do in parallel, consuming input items and fluids and considering input voltage limits
 		for (; parallelRecipes < aMaxParallelRecipes && tTotalEUt < (tVoltage - tRecipeEUt); parallelRecipes++) {
 			if (!tRecipe.isRecipeInputEqual(true, aFluidInputs, aItemInputs)) {
@@ -219,11 +217,17 @@ GT_MetaTileEntity_MultiBlockBase {
 			tTotalEUt += tRecipeEUt;
 		}
 
-		this.mEUt = (int)Math.ceil(tTotalEUt);
-
 		if (parallelRecipes == 0) {
 			return false;
 		}
+
+		// Convert speed bonus to duration multiplier
+		// e.g. 100% speed bonus = 200% speed = 100%/200% = 50% recipe duration.
+		aSpeedBonusPercent = Math.max(-99, aSpeedBonusPercent);
+		float tTimeFactor = 100.0f / (100.0f + aSpeedBonusPercent);
+		this.mMaxProgresstime = (int)(tRecipe.mDuration * tTimeFactor);
+
+		this.mEUt = (int)Math.ceil(tTotalEUt);
 
 		this.mEfficiency = (10000 - (getIdealStatus() - getRepairStatus()) * 1000);
 		this.mEfficiencyIncrease = 10000;

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_AlloyBlastSmelter.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_AlloyBlastSmelter.java
@@ -61,6 +61,11 @@ extends GregtechMeta_MultiBlockBase {
 	}
 
 	@Override
+	public String getSound() {
+		return GregTech_API.sSoundList.get(Integer.valueOf(208));
+	}
+
+	@Override
 	public ITexture[] getTexture(final IGregTechTileEntity aBaseMetaTileEntity, final byte aSide, final byte aFacing, final byte aColorIndex, final boolean aActive, final boolean aRedstone) {
 		if (aSide == aFacing) {
 			return new ITexture[]{Textures.BlockIcons.CASING_BLOCKS[TAE.GTPP_INDEX(15)], new GT_RenderedTexture(aActive ? Textures.BlockIcons.OVERLAY_FRONT_ELECTRIC_BLAST_FURNACE_ACTIVE : Textures.BlockIcons.OVERLAY_FRONT_ELECTRIC_BLAST_FURNACE)};
@@ -81,19 +86,6 @@ extends GregtechMeta_MultiBlockBase {
 	@Override
 	public boolean isCorrectMachinePart(final ItemStack aStack) {
 		return true;
-	}
-
-	@Override
-	public void startSoundLoop(final byte aIndex, final double aX, final double aY, final double aZ) {
-		super.startSoundLoop(aIndex, aX, aY, aZ);
-		if (aIndex == 1) {
-			GT_Utility.doSoundAtClient(GregTech_API.sSoundList.get(Integer.valueOf(208)), 10, 1.0F, aX, aY, aZ);
-		}
-	}
-
-	@Override
-	public void startProcess() {
-		this.sendLoopStart((byte) 1);
 	}
 
 	@Override

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_Cyclotron.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_Cyclotron.java
@@ -28,7 +28,6 @@ import net.minecraftforge.fluids.FluidStack;
 
 public class GregtechMetaTileEntity_Cyclotron extends GregtechMeta_MultiBlockBase {
 
-	public GT_Recipe mLastRecipe;
 	public int mEUStore;
 
 	public GregtechMetaTileEntity_Cyclotron(int aID, String aName, String aNameRegional, int tier) {

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialCuttingMachine.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialCuttingMachine.java
@@ -1,7 +1,5 @@
 package gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi;
 
-import java.util.ArrayList;
-
 import gregtech.api.enums.TAE;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.ITexture;
@@ -11,7 +9,6 @@ import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Maintenance;
 import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.util.GT_Recipe;
-import gregtech.api.util.GT_Utility;
 import gtPlusPlus.api.objects.Logger;
 import gtPlusPlus.core.block.ModBlocks;
 import gtPlusPlus.core.lib.CORE;
@@ -20,7 +17,6 @@ import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.base.Gregtech
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
-import net.minecraftforge.fluids.FluidStack;
 
 public class GregtechMetaTileEntity_IndustrialCuttingMachine
 extends GregtechMeta_MultiBlockBase {
@@ -78,53 +74,7 @@ extends GregtechMeta_MultiBlockBase {
 
 	@Override
 	public boolean checkRecipe(final ItemStack aStack) {
-		final ArrayList<ItemStack> tInputList = this.getStoredInputs();
-		final ArrayList<FluidStack> tFluidList = this.getStoredFluids();
-		for (final ItemStack tInput : tInputList) {
-			for (final FluidStack tFluid : tFluidList) {
-				final long tVoltage = this.getMaxInputVoltage();
-				final byte tTier = (byte) Math.max(1, GT_Utility.getTier(tVoltage));
-
-				GT_Recipe tRecipe = GT_Recipe.GT_Recipe_Map.sCutterRecipes.findRecipe(this.getBaseMetaTileEntity(), false, gregtech.api.enums.GT_Values.V[tTier], new FluidStack[]{tFluid}, new ItemStack[]{tInput});
-				//tRecipe = this.reduceRecipeTimeByPercentage(tRecipe, 60F);
-				if (tRecipe != null) {
-
-					//More than or one input
-					if (tInputList.size() > 0) {
-
-						if (tRecipe.isRecipeInputEqual(true, new FluidStack[]{tFluid}, new ItemStack[]{tInput})) {
-							this.mEfficiency = (10000 - ((this.getIdealStatus() - this.getRepairStatus()) * 1000));
-							this.mEfficiencyIncrease = 10000;
-							if (tRecipe.mEUt <= 16) {
-								this.mEUt = (tRecipe.mEUt * (1 << (tTier - 1)) * (1 << (tTier - 1)));
-								this.mMaxProgresstime = (tRecipe.mDuration / (1 << (tTier - 1)));
-							} else {
-								this.mEUt = tRecipe.mEUt;
-								this.mMaxProgresstime = tRecipe.mDuration;
-								while (this.mEUt <= gregtech.api.enums.GT_Values.V[(tTier - 1)]) {
-									this.mEUt *= 4;
-									this.mMaxProgresstime /= 2;
-								}
-							}
-							if (this.mEUt > 0) {
-								this.mEUt = (-this.mEUt);
-							}
-							this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
-							ItemStack[] mOutputStacks = new ItemStack[9];
-							for (int i=0;i<9;i++){
-								if (tRecipe.getOutput(i) != null){
-									mOutputStacks[i] = tRecipe.getOutput(i);
-								}
-							}
-							this.mOutputItems = mOutputStacks.clone();
-							//this.updateSlots();
-							return true;
-						}
-					}
-				}
-			}
-		}
-		return false;
+		return checkRecipeGeneric(2, 100, 60);
 	}
 
 	@Override
@@ -217,7 +167,7 @@ extends GregtechMeta_MultiBlockBase {
 
 	@Override
 	public int getPollutionPerTick(final ItemStack aStack) {
-		return 80;
+		return 0;
 	}
 
 	@Override

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialThermalCentrifuge.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialThermalCentrifuge.java
@@ -140,26 +140,28 @@ extends GregtechMeta_MultiBlockBase {
 		int tAmount = 0;
 		for (int i = -1; i < 2; ++i) {
 			for (int j = -1; j < 2; ++j) {
-				for (int h = -1; h < 0; ++h) {
-					if ((h != 0) || ((((xDir + i != 0) || (zDir + j != 0))) && (((i != 0) || (j != 0))))) {
-						IGregTechTileEntity tTileEntity = aBaseMetaTileEntity.getIGregTechTileEntityOffset(xDir + i, h,
-								zDir + j);
+				for (int h = -1; h < 1; ++h) {
+					if ((xDir + i == 0) && (zDir + j == 0) && (h == 0)) continue; // controller block
 
-						Logger.INFO("------------------");
-						Logger.INFO("xDir: "+xDir+" | zDir: "+zDir);
-						Logger.INFO("i: "+i+" | j: "+j+" | h: "+h);
-						if (!addToMachineList(tTileEntity)) {
-							Block tBlock = aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j);
-							byte tMeta = aBaseMetaTileEntity.getMetaIDOffset(xDir + i, h, zDir + j);
-							if ((((tBlock != ModBlocks.blockCasings2Misc) || (tMeta != 0)))
-									&& (((tBlock != GregTech_API.sBlockCasings3) || (tMeta != 9)))) {
-								Logger.INFO("Wrong Block?");
-								return false;
-							}
-							tAmount++;
+					IGregTechTileEntity tTileEntity = aBaseMetaTileEntity.getIGregTechTileEntityOffset(xDir + i, h,
+							zDir + j);
+
+					Logger.INFO("------------------");
+					Logger.INFO("xDir: " + xDir + " | zDir: " + zDir);
+					Logger.INFO("i: " + i + " | j: " + j + " | h: " + h);
+					if ((h == 0) || !addToMachineList(tTileEntity)) { // only bottom layer allows machine parts
+						// top layer, or not machine part, must be casing
+						Block tBlock = aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j);
+						byte tMeta = aBaseMetaTileEntity.getMetaIDOffset(xDir + i, h, zDir + j);
+						if ((((tBlock != ModBlocks.blockCasings2Misc) || (tMeta != 0)))
+								&& (((tBlock != GregTech_API.sBlockCasings3) || (tMeta != 9)))) {
+							Logger.INFO("Wrong Block?");
+							return false;
 						}
+						tAmount++;
 					}
 				}
+
 			}
 		}
 		Logger.INFO("------------------");

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialThermalCentrifuge.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialThermalCentrifuge.java
@@ -1,7 +1,5 @@
 package gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi;
 
-import java.util.ArrayList;
-
 import gregtech.api.GregTech_API;
 import gregtech.api.enums.TAE;
 import gregtech.api.enums.Textures;
@@ -10,7 +8,6 @@ import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.util.GT_Recipe;
-import gregtech.api.util.GT_Utility;
 import gtPlusPlus.api.objects.Logger;
 import gtPlusPlus.core.block.ModBlocks;
 import gtPlusPlus.core.lib.CORE;
@@ -79,55 +76,7 @@ extends GregtechMeta_MultiBlockBase {
 
 	@Override
 	public boolean checkRecipe(final ItemStack aStack) {
-		final ArrayList<ItemStack> tInputList = this.getStoredInputs();
-		for (final ItemStack tInput : tInputList) {
-			final long tVoltage = this.getMaxInputVoltage();
-			final byte tTier = (byte) Math.max(1, GT_Utility.getTier(tVoltage));
-
-			GT_Recipe tRecipe = GT_Recipe.GT_Recipe_Map.sThermalCentrifugeRecipes.findRecipe(this.getBaseMetaTileEntity(), false, gregtech.api.enums.GT_Values.V[tTier], null, new ItemStack[]{tInput});
-			tRecipe = this.reduceRecipeTimeByPercentage(tRecipe, 60F);
-			if (tRecipe != null) {
-
-				final int tValidOutputSlots = this.getValidOutputSlots(this.getBaseMetaTileEntity(), tRecipe, new ItemStack[]{tInput});
-				Logger.WARNING("Valid Output Slots: "+tValidOutputSlots);
-				//More than or one input
-				if ((tInputList.size() > 0) && (tValidOutputSlots >= 1)) {
-
-					if (tRecipe.isRecipeInputEqual(true, null, new ItemStack[]{tInput})) {
-						this.mEfficiency = (10000 - ((this.getIdealStatus() - this.getRepairStatus()) * 1000));
-						this.mEfficiencyIncrease = 10000;
-						if (tRecipe.mEUt <= 16) {
-							this.mEUt = (tRecipe.mEUt * (1 << (tTier - 1)) * (1 << (tTier - 1)));
-							this.mMaxProgresstime = (tRecipe.mDuration / (1 << (tTier - 1)));
-						} else {
-							this.mEUt = tRecipe.mEUt;
-							this.mMaxProgresstime = tRecipe.mDuration;
-							while (this.mEUt <= gregtech.api.enums.GT_Values.V[(tTier - 1)]) {
-								this.mEUt *= 4;
-								this.mMaxProgresstime /= 2;
-							}
-						}
-						if (this.mEUt > 0) {
-							this.mEUt = (-this.mEUt);
-						}
-						this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
-						
-						ItemStack mNewOutputs[] = new ItemStack[16];
-						
-
-						
-						for (int f=0;f<tRecipe.mOutputs.length;f++){
-							mNewOutputs[f] = tRecipe.getOutput(f);
-						}
-						
-						this.mOutputItems = mNewOutputs;
-						this.updateSlots();
-						return true;
-					}
-				}
-			}
-		}
-		return false;
+		return checkRecipeGeneric(2, 100, 60);
 	}
 
 	@Override

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialWashPlant.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialWashPlant.java
@@ -1,6 +1,5 @@
 package gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi;
 
-import java.util.ArrayList;
 import gregtech.api.enums.TAE;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.ITexture;
@@ -8,12 +7,10 @@ import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.util.GT_Recipe;
-import gregtech.api.util.GT_Utility;
 import gtPlusPlus.api.objects.Logger;
 import gtPlusPlus.core.block.ModBlocks;
 import gtPlusPlus.core.lib.CORE;
 import gtPlusPlus.core.util.fluid.FluidUtils;
-import gtPlusPlus.core.util.math.MathUtils;
 import gtPlusPlus.xmod.gregtech.api.gui.GUI_MultiMachine;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.base.GregtechMeta_MultiBlockBase;
 import ic2.core.init.BlocksItems;
@@ -28,7 +25,6 @@ import net.minecraftforge.fluids.FluidStack;
 public class GregtechMetaTileEntity_IndustrialWashPlant
 extends GregtechMeta_MultiBlockBase {
 
-	public GT_Recipe mLastRecipe;
 
 	public GregtechMetaTileEntity_IndustrialWashPlant(final int aID, final String aName, final String aNameRegional) {
 		super(aID, aName, aNameRegional);
@@ -86,70 +82,8 @@ extends GregtechMeta_MultiBlockBase {
 	}
 
 	@Override
-	public boolean checkRecipe(final ItemStack aStack) { //TODO - Add Check to make sure Fluid output isn't full
-		ArrayList<ItemStack> tInputList = getStoredInputs();
-		ArrayList<FluidStack> tFluidInputs = getStoredFluids();
-		for (ItemStack tInput : tInputList) {
-
-			if (tInput.stackSize >= 2){
-
-				long tVoltage = getMaxInputVoltage();
-				byte tTier = (byte) Math.max(1, GT_Utility.getTier(tVoltage));
-				GT_Recipe tRecipe = GT_Recipe.GT_Recipe_Map.sOreWasherRecipes.findRecipe(getBaseMetaTileEntity(), this.mLastRecipe, false, gregtech.api.enums.GT_Values.V[tTier], tFluidInputs.isEmpty() ? null : new FluidStack[]{tFluidInputs.get(0)}, new ItemStack[]{tInput});
-
-				if ((tRecipe == null && !mRunningOnLoad)) {
-					this.mLastRecipe = null;
-					return false;
-				}
-
-				if (tRecipe != null) {
-					FluidStack[] mFluidInputList = new FluidStack[tFluidInputs.size()];
-					int tri = 0;
-					for (FluidStack f : tFluidInputs){
-						mFluidInputList[tri] = f;
-						tri++;
-					}
-					if (tRecipe.isRecipeInputEqual(true, mFluidInputList, tInput)) {
-						this.mEfficiency = (10000 - (getIdealStatus() - getRepairStatus()) * 1000);
-						this.mEfficiencyIncrease = 10000;
-						this.mEUt = tRecipe.mEUt;
-
-						if (tRecipe.mEUt <= 16) {
-							this.mEUt = (tRecipe.mEUt * (1 << tTier - 1) * (1 << tTier - 1));
-							this.mMaxProgresstime = (tRecipe.mDuration / (1 << tTier - 1));
-						} else {
-							this.mEUt = tRecipe.mEUt;
-							this.mMaxProgresstime = tRecipe.mDuration;
-							while (this.mEUt <= gregtech.api.enums.GT_Values.V[(tTier - 1)]) {
-								this.mEUt *= 4;
-								this.mMaxProgresstime /= 2;
-							}
-						}
-						if (this.mEUt > 0) {
-							this.mEUt = (-this.mEUt);
-						}
-						this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
-
-						if (mRunningOnLoad || tRecipe.isRecipeInputEqual(true, mFluidInputList, new ItemStack[]{tInput})) {
-							Logger.WARNING("Recipe Complete.");
-							this.mLastRecipe = tRecipe;
-							this.mEUt = MathUtils.findPercentageOfInt(this.mLastRecipe.mEUt, 80);
-							this.mMaxProgresstime = MathUtils.findPercentageOfInt(this.mLastRecipe.mDuration, 20);
-							this.mEfficiencyIncrease = 10000;
-							this.addOutput(tRecipe.getOutput(0));
-							this.addOutput(tRecipe.getOutput(0));
-							this.addOutput(tRecipe.getOutput(1));
-							this.addOutput(tRecipe.getOutput(1));
-							mRunningOnLoad = false;	
-							this.updateSlots();
-							return true;
-						}
-
-					}
-				}
-			}
-		}
-		return false;
+	public boolean checkRecipe(final ItemStack aStack) {
+		return checkRecipeGeneric(2, 100, 80);
 	}
 
 	@Override
@@ -246,7 +180,7 @@ extends GregtechMeta_MultiBlockBase {
 
 	@Override
 	public int getPollutionPerTick(final ItemStack aStack) {
-		return 20;
+		return 0;
 	}
 
 	@Override

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialWireMill.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialWireMill.java
@@ -1,7 +1,6 @@
 package gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi;
 
-import java.util.ArrayList;
-
+import gregtech.api.GregTech_API;
 import gregtech.api.enums.TAE;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.ITexture;
@@ -11,11 +10,9 @@ import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Maintenance;
 import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.util.GT_Recipe;
-import gregtech.api.util.GT_Utility;
 import gtPlusPlus.api.objects.Logger;
 import gtPlusPlus.core.block.ModBlocks;
 import gtPlusPlus.core.lib.CORE;
-import gtPlusPlus.core.util.math.MathUtils;
 import gtPlusPlus.xmod.gregtech.api.gui.GUI_MultiMachine;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.base.GregtechMeta_MultiBlockBase;
 import net.minecraft.block.Block;
@@ -53,6 +50,11 @@ extends GregtechMeta_MultiBlockBase {
 	}
 
 	@Override
+	public String getSound() {
+		return GregTech_API.sSoundList.get(Integer.valueOf(204));
+	}
+
+	@Override
 	public ITexture[] getTexture(final IGregTechTileEntity aBaseMetaTileEntity, final byte aSide, final byte aFacing, final byte aColorIndex, final boolean aActive, final boolean aRedstone) {
 		if (aSide == aFacing) {
 			return new ITexture[]{Textures.BlockIcons.CASING_BLOCKS[TAE.GTPP_INDEX(6)], new GT_RenderedTexture(aActive ? Textures.BlockIcons.OVERLAY_FRONT_VACUUM_FREEZER_ACTIVE : Textures.BlockIcons.OVERLAY_FRONT_VACUUM_FREEZER)};
@@ -77,46 +79,7 @@ extends GregtechMeta_MultiBlockBase {
 
 	@Override
 	public boolean checkRecipe(final ItemStack aStack) {
-		final ArrayList<ItemStack> tInputList = this.getStoredInputs();
-		for (final ItemStack tInput : tInputList) {
-			final long tVoltage = this.getMaxInputVoltage();
-			final byte tTier = (byte) Math.max(1, GT_Utility.getTier(tVoltage));
-
-			GT_Recipe tRecipe = GT_Recipe.GT_Recipe_Map.sWiremillRecipes.findRecipe(this.getBaseMetaTileEntity(), false, gregtech.api.enums.GT_Values.V[tTier], null, new ItemStack[]{tInput});
-			tRecipe = this.reduceRecipeTimeByPercentage(tRecipe, 60F);
-			if (tRecipe != null) {
-
-				final int tValidOutputSlots = this.getValidOutputSlots(this.getBaseMetaTileEntity(), tRecipe, new ItemStack[]{tInput});
-				Logger.WARNING("Valid Output Slots: "+tValidOutputSlots);
-				//More than or one input
-				if ((tInputList.size() > 0) && (tValidOutputSlots >= 1)) {
-
-					if (tRecipe.isRecipeInputEqual(true, null, new ItemStack[]{tInput})) {
-						this.mEfficiency = (10000 - ((this.getIdealStatus() - this.getRepairStatus()) * 1000));
-						this.mEfficiencyIncrease = 10000;
-						if (tRecipe.mEUt <= 16) {
-							this.mEUt = (tRecipe.mEUt * (1 << (tTier - 1)) * (1 << (tTier - 1)));
-							this.mMaxProgresstime = (tRecipe.mDuration / (1 << (tTier - 1)));
-						} else {
-							this.mEUt = tRecipe.mEUt;
-							this.mMaxProgresstime = tRecipe.mDuration;
-							while (this.mEUt <= gregtech.api.enums.GT_Values.V[(tTier - 1)]) {
-								this.mEUt *= 4;
-								this.mMaxProgresstime /= 2;
-							}
-						}
-						if (this.mEUt > 0) {
-							this.mEUt = (-this.mEUt);
-						}
-						this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
-						this.mOutputItems = new ItemStack[]{tRecipe.getOutput(0)};
-						this.updateSlots();
-						return true;
-					}
-				}
-			}
-		}
-		return false;
+		return checkRecipeGeneric(2, 100, 60);
 	}
 
 	@Override


### PR DESCRIPTION
Fixes #182, #183, #184

`checkRecipeGeneric()` implements parallel processing, EU/t discounts
and speed boosts, increased random chances, and can be used to consider
each input bus individually (as seen in the Industrial Material Press)
to allow each bus to use a different Configuration Circuit. Also
considers the voltage input limit of the multiblock when counting
recipes to do in parallel - if the energy hatch is too small, it will
process fewer recipes at once. Plays the machine's sound, if any, on
success.

`checkRecipeGeneric()` also checks `canBufferOutput()` and will pause
the machine if it has no bus/hatch room for the recipe output.

`getValidOutputSlots()` is rewritten as `canBufferOutput()`, which
now checks both the item output buses and fluid output hatches to make
sure recipe output can be accepted. This is used to pause a machine
instead of allowing it to continue working and void outputs, if the
outputs can't be stored in a bus and/or hatch. NOTE:
`canBufferOutput()` doesn't consider parallel processing, so there are
a few recipes where, if done in parallel, it may get a false positive on
the buffer check and void some outputs. In practice, this will rarely
happen.

Removed unused imports, fields, and locals.

Industrial Centrifuge now uses `checkRecipeGeneric()` with 4 parallel
recipes and a 40% speed boost.

Industrial Coke Oven now uses `checkRecipeGeneric()` with 12 parallel
recipes if using Heat-Resistant Casings, or 24 if using Heat-Proof
Casings. Sound plays while processing.

Industrial Cutting Machine now uses `checkRecipeGeneric()` with 2
parallel recipes and a 60% speed boost. Pollution removed since the
Machine is built with no Muffler Hatch.

Industrial Electrolyzer now uses `checkRecipeGeneric()` with 2 parallel
recipes and a 40% speed boost.

Maceration Stack now uses `checkRecipeGeneric()` with 8*tTier
parallel recipes, a 60% speed boost, and an increased amount (~33%) of
random outputs. Sound plays while processing.

Material Press now uses `checkRecipeGeneric()` with 2 parallel recipes
and a 50% speed boost. Each input bus is considered separately for
finding recipes, allowing each bus to hold a different Configuration
Circuit. Sound plays while processing.

Industrial Sifter now uses `checkRecipeGeneric()` with 2 parallel
recipes, a 400% speed boost, and an increased amount (~15%) of random
outputs. Changed particles to appear above the sieve grates.

Industrial Thermal Centrifuge now uses `checkRecipeGeneric()` with 2
parallel recipes and a 60% speed boost.

Industrial Washing Plant now uses `checkRecipeGeneric()` with 2
parallel recipes and an 80% speed boost. Stone Dust outputs are no
longer deleted.

Wire Factory now uses `checkRecipeGeneric()` with 2 parallel recipes
and a 60% speed boost. Sound plays while processing.

Fix #184 - Large Thermal Centrifuge not completing multiblock