### PR TITLE
Allow for compilation on case sensitive filesystems

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ apply plugin: "forge"
 
 sourceSets {
     main {
-        java { srcDirs = ["$projectDir/src/java"] }
+        java { srcDirs = ["$projectDir/src/Java"] }
         resources { srcDirs = ["$projectDir/src/resources"] }
     }
 }


### PR DESCRIPTION
Fixes compilation on case sensitive filenames.

Was scratching my head for a while trying to figure out why I was only getting the resources folder compiled into the jar.