### PR TITLE
Fix Industrial Centrifuge not processing Gendustry customized combs

### DIFF
--- a/src/Java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
@@ -121,6 +121,11 @@ GT_MetaTileEntity_MultiBlockBase {
 	public String getSound() { return ""; }
 
 	public boolean canBufferOutputs(final GT_Recipe aRecipe, int aParallelRecipes) {
+		if (aRecipe.mOutputs.length > 16) {
+			// Gendustry custom comb with a billion centrifuge outputs? Do it anyway.
+			return true;
+		}
+		
 		// Count slots available in output buses
 		ArrayList<ItemStack> tBusStacks = new ArrayList<>();
 

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialCentrifuge.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialCentrifuge.java
@@ -55,7 +55,7 @@ extends GregtechMeta_MultiBlockBase {
 				"1x Input Hatch",
 				"1x Output Hatch",
 				"1x Input Bus",
-				"1x Output Bus",
+				"1x [HV] Output Bus",
 				"1x [EV] Energy Hatch (Can be higher Tier) [Blue]",
 				"Centrifuge Casings for the rest (16 at least)",
 				CORE.GT_Tooltip};


### PR DESCRIPTION
Pass the buffer check if the recipe has more than 16 outputs.