### PR TITLE
 Improve Industrial Information Panel readout for Energy Buffers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,10 @@ buildscript {
 }
 
 apply plugin: "forge"
+apply plugin: "idea"
+
+idea { module { inheritOutputDirs = true } }
+
 
 sourceSets {
     main {

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/generators/creative/GregtechMetaCreativeEnergyBuffer.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/generators/creative/GregtechMetaCreativeEnergyBuffer.java
@@ -11,6 +11,7 @@ import gregtech.api.items.GT_MetaBase_Item;
 import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_Utility;
+import gtPlusPlus.core.lib.CORE;
 import gtPlusPlus.xmod.gregtech.common.tileentities.storage.GregtechMetaEnergyBuffer;
 import ic2.api.item.IElectricItem;
 import net.minecraft.entity.player.EntityPlayer;
@@ -41,7 +42,7 @@ public class GregtechMetaCreativeEnergyBuffer extends GregtechMetaEnergyBuffer {
 
 	@Override
 	public String[] getDescription() {
-		return new String[] {this.mDescription, "Added by: "	+ EnumChatFormatting.DARK_GREEN+"Alkalus"};
+		return new String[] {this.mDescription, CORE.GT_Tooltip};
 	}
 
 	/*
@@ -75,16 +76,6 @@ public class GregtechMetaCreativeEnergyBuffer extends GregtechMetaEnergyBuffer {
 				this.mTextures, this.mInventory.length);
 	}
 
-	@Override public boolean isSimpleMachine()						{return false;}
-	@Override public boolean isElectric()							{return true;}
-	@Override public boolean isValidSlot(final int aIndex)				{return true;}
-	@Override public boolean isFacingValid(final byte aFacing)			{return true;}
-	@Override public boolean isEnetInput() 							{return true;}
-	@Override public boolean isEnetOutput() 						{return true;}
-	@Override public boolean isInputFacing(final byte aSide)				{return aSide!=this.getBaseMetaTileEntity().getFrontFacing();}
-	@Override public boolean isOutputFacing(final byte aSide)				{return aSide==this.getBaseMetaTileEntity().getFrontFacing();}
-	@Override public boolean isTeleporterCompatible()				{return false;}
-
 	@Override
 	public long getMinimumStoredEU() {
 		return 0;
@@ -107,19 +98,16 @@ public class GregtechMetaCreativeEnergyBuffer extends GregtechMetaEnergyBuffer {
 
 	@Override
 	public long maxAmperesIn() {
-		return this.mChargeableCount * 16;
+		return 16;
 	}
 
 	@Override
 	public long maxAmperesOut() {
-		return this.mChargeableCount * 16;
+		return 16;
 	}
-	@Override public int rechargerSlotStartIndex()					{return 0;}
-	@Override public int dechargerSlotStartIndex()					{return 0;}
-	@Override public int rechargerSlotCount()						{return this.mCharge?this.mInventory.length:0;}
-	@Override public int dechargerSlotCount()						{return this.mDecharge?this.mInventory.length:0;}
+
 	@Override public int getProgresstime()							{return Integer.MAX_VALUE;}
-	@Override public int maxProgresstime()							{return (int)this.getBaseMetaTileEntity().getUniversalEnergyCapacity();}
+	@Override public int maxProgresstime()							{return Integer.MAX_VALUE;}
 	@Override public boolean isAccessAllowed(final EntityPlayer aPlayer)	{return true;}
 
 	@Override
@@ -153,31 +141,14 @@ public class GregtechMetaCreativeEnergyBuffer extends GregtechMetaEnergyBuffer {
 	}
 
 	@Override
-	public long[] getStoredEnergy(){
-		long tScale = this.getBaseMetaTileEntity().getEUCapacity();
-		long tStored = this.getBaseMetaTileEntity().getStoredEU();
-		//this.setEUVar(Long.MAX_VALUE);
-		return new long[] { tStored, tScale };
-	}
-
-	private long count=0;
-	private long mStored=0;
-	private long mMax=0;
-
-	@Override
 	public String[] getInfoData() {
-		this.count++;
-		if((this.mMax==0)||((this.count%20)==0)){
-			final long[] tmp = this.getStoredEnergy();
-			this.mStored=tmp[0];
-			this.mMax=tmp[1];
-		}
-
+		String[] infoData = super.getInfoData();
 		return new String[] {
-				this.getLocalName(),
+				infoData[0],
 				"THIS IS A CREATIVE ITEM - FOR TESTING",
-				GT_Utility.formatNumbers(this.mStored)+" EU /",
-				GT_Utility.formatNumbers(this.mMax)+" EU"};
+				infoData[1],
+				infoData[2]
+		};
 	}
 
 	@Override

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/storage/GregtechMetaEnergyBuffer.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/storage/GregtechMetaEnergyBuffer.java
@@ -31,9 +31,6 @@ public class GregtechMetaEnergyBuffer extends GregtechMetaTileEntity {
 	 * setCreativeTab(GregTech_API.TAB_GREGTECH); }
 	 */
 
-	public boolean mCharge = false, mDecharge = false;
-	public int mBatteryCount = 1, mChargeableCount = 1;
-
 	public GregtechMetaEnergyBuffer(final int aID, final String aName, final String aNameRegional, final int aTier, final String aDescription, final int aSlotCount) {
 		super(aID, aName, aNameRegional, aTier, aSlotCount, aDescription);
 	}
@@ -195,17 +192,17 @@ public class GregtechMetaEnergyBuffer extends GregtechMetaTileEntity {
 
 	@Override
 	public long maxAmperesIn() {
-		return this.mChargeableCount * 4;
+		return 4;
 	}
 
 	@Override
 	public long maxAmperesOut() {
-		return this.mChargeableCount * 4;
+		return 4;
 	}
 	@Override public int rechargerSlotStartIndex()					{return 0;}
 	@Override public int dechargerSlotStartIndex()					{return 0;}
-	@Override public int rechargerSlotCount()						{return this.mCharge?this.mInventory.length:0;}
-	@Override public int dechargerSlotCount()						{return this.mDecharge?this.mInventory.length:0;}
+	@Override public int rechargerSlotCount()						{return 0;}
+	@Override public int dechargerSlotCount()						{return 0;}
 	@Override public int getProgresstime()							{return (int)this.getBaseMetaTileEntity().getUniversalEnergyStored();}
 	@Override public int maxProgresstime()							{return (int)this.getBaseMetaTileEntity().getUniversalEnergyCapacity();}
 	@Override public boolean isAccessAllowed(final EntityPlayer aPlayer)	{return true;}
@@ -235,10 +232,10 @@ public class GregtechMetaEnergyBuffer extends GregtechMetaTileEntity {
 	}
 
 	private void showEnergy(final World worldIn, final EntityPlayer playerIn){
-		final long tempStorage = this.getStoredEnergy()[0];
+		final long tempStorage = this.getBaseMetaTileEntity().getStoredEU();
 		final double c = ((double) tempStorage / this.maxEUStore()) * 100;
 		final double roundOff = Math.round(c * 100.00) / 100.00;
-		PlayerUtils.messagePlayer(playerIn, "Energy: " + tempStorage + " EU at "+V[this.mTier]+"v ("+roundOff+"%)");
+		PlayerUtils.messagePlayer(playerIn, "Energy: " + GT_Utility.formatNumbers(tempStorage) + " EU at "+V[this.mTier]+"v ("+roundOff+"%)");
 
 	}
 	//Utils.LOG_WARNING("Begin Show Energy");
@@ -270,11 +267,6 @@ public class GregtechMetaEnergyBuffer extends GregtechMetaTileEntity {
 	}
 
 	@Override
-	public void onPostTick(final IGregTechTileEntity aBaseMetaTileEntity, final long aTick) {
-
-	}
-
-	@Override
 	public boolean allowPullStack(final IGregTechTileEntity aBaseMetaTileEntity, final int aIndex, final byte aSide, final ItemStack aStack) {
 		return false;
 	}
@@ -284,54 +276,19 @@ public class GregtechMetaEnergyBuffer extends GregtechMetaTileEntity {
 		return false;
 	}
 
-	public long[] getStoredEnergy(){
-		long tScale = this.getBaseMetaTileEntity().getEUCapacity();
-		long tStored = this.getBaseMetaTileEntity().getStoredEU();
-		if (this.mInventory != null) {
-			for (final ItemStack aStack : this.mInventory) {
-				if (GT_ModHandler.isElectricItem(aStack)) {
-
-					if (aStack.getItem() instanceof GT_MetaBase_Item) {
-						final Long[] stats = ((GT_MetaBase_Item) aStack.getItem())
-								.getElectricStats(aStack);
-						if (stats != null) {
-							tScale = tScale + stats[0];
-							tStored = tStored
-									+ ((GT_MetaBase_Item) aStack.getItem())
-									.getRealCharge(aStack);
-						}
-					} else if (aStack.getItem() instanceof IElectricItem) {
-						tStored = tStored
-								+ (long) ic2.api.item.ElectricItem.manager
-								.getCharge(aStack);
-						tScale = tScale
-								+ (long) ((IElectricItem) aStack.getItem())
-								.getMaxCharge(aStack);
-					}
-				}
-			}
-
-		}
-		return new long[] { tStored, tScale };
-	}
-
-	private long count=0;
-	private long mStored=0;
-	private long mMax=0;
-
 	@Override
 	public String[] getInfoData() {
-		this.count++;
-		if((this.mMax==0)||((this.count%20)==0)){
-			final long[] tmp = this.getStoredEnergy();
-			this.mStored=tmp[0];
-			this.mMax=tmp[1];
-		}
+		String cur = GT_Utility.formatNumbers(this.getBaseMetaTileEntity().getStoredEU());
+		String max = GT_Utility.formatNumbers(this.getBaseMetaTileEntity().getEUCapacity());
+
+		// Right-align current storage with maximum storage
+		String fmt = String.format("%%%ds", max.length());
+		cur = String.format(fmt, cur);
 
 		return new String[] {
 				this.getLocalName(),
-				GT_Utility.formatNumbers(this.mStored)+" EU /",
-				GT_Utility.formatNumbers(this.mMax)+" EU"};
+				cur+" EU stored",
+				max+" EU capacity"};
 	}
 
 	@Override


### PR DESCRIPTION
Remove code related to inventory slots
Remove redundant overrides in Creative Energy Buffer
Remove inventory-related delay from info data update
Right-align numbers in info data readout
Format current storage number in right-click chat readout

![image](https://user-images.githubusercontent.com/307683/36050461-b164e33e-0d8a-11e8-8d7a-d96b8e5ce9dc.png)
