### PR TITLE
Fix multiblocks not forming on server startup

### DIFF
--- a/src/Java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
@@ -422,7 +422,7 @@ GT_MetaTileEntity_MultiBlockBase {
 		}
 		
 		if (aBaseMetaTileEntity.isServerSide()) {
-			if (mUpdate == 0 || --this.mStartUpCheck == 0) {
+			if (mUpdate == 0 || this.mStartUpCheck == 0) {
 				this.mChargeHatches.clear();
 				this.mDischargeHatches.clear();
 			}

--- a/src/Java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
@@ -169,6 +169,7 @@ GT_MetaTileEntity_MultiBlockBase {
 
 		int slotsNeeded = aRecipe.mOutputs.length;
 		for (final ItemStack tRecipeOutput: aRecipe.mOutputs) {
+			if (tRecipeOutput == null) continue;
 			int amount = tRecipeOutput.stackSize * aParallelRecipes;
 			for (final ItemStack tBusStack : tBusStacks) {
 				if (GT_Utility.areStacksEqual(tBusStack, tRecipeOutput)) {
@@ -184,6 +185,7 @@ GT_MetaTileEntity_MultiBlockBase {
 
 		// For each output fluid, make sure an output hatch can accept it.
 		for (FluidStack tRecipeFluid: aRecipe.mFluidOutputs) {
+			if (tRecipeFluid == null) continue;
 			boolean tCanBufferFluid = false;
 			int tRecipeAmount = tRecipeFluid.amount;
 			for (final GT_MetaTileEntity_Hatch_Output tHatch : this.mOutputHatches) {


### PR DESCRIPTION
Also guard against null outputs in `canBufferOutput`