### PR TITLE
Remove `Utils.calculateVoltageTier` in favor of `GT_Utility.getTier`

### DIFF
--- a/src/Java/gtPlusPlus/core/util/Utils.java
+++ b/src/Java/gtPlusPlus/core/util/Utils.java
@@ -567,34 +567,6 @@ public class Utils {
 
 	}
 
-	public static int calculateVoltageTier(final long Voltage) {
-		int V;
-		if (Voltage == 8) {
-			V = 0;
-		} else if (Voltage == 32) {
-			V = 1;
-		} else if (Voltage == 128) {
-			V = 2;
-		} else if (Voltage == 512) {
-			V = 3;
-		} else if (Voltage == 2048) {
-			V = 4;
-		} else if (Voltage == 8196) {
-			V = 5;
-		} else if (Voltage == 32768) {
-			V = 6;
-		} else if (Voltage == 131072) {
-			V = 7;
-		} else if (Voltage == 524288) {
-			V = 8;
-		} else if (Voltage == Integer.MAX_VALUE) {
-			V = 9;
-		} else {
-			V = -1;
-		}
-		return V;
-	}
-
 	public static String[] parseVersion(final String version) {
 		return parseVersion(version, "//.");
 	}

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialCentrifuge.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialCentrifuge.java
@@ -13,7 +13,7 @@ import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Maintenance;
 import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.util.GT_Recipe;
-
+import gregtech.api.util.GT_Utility;
 import gtPlusPlus.api.objects.Logger;
 import gtPlusPlus.core.block.ModBlocks;
 import gtPlusPlus.core.lib.CORE;
@@ -93,7 +93,7 @@ extends GregtechMeta_MultiBlockBase {
 
 	@Override
 	public boolean checkRecipe(final ItemStack aStack) {
-		return checkRecipeGeneric(6*Utils.calculateVoltageTier(this.getMaxInputVoltage()), 90, 125);
+		return checkRecipeGeneric(6* GT_Utility.getTier(this.getMaxInputVoltage()), 90, 125);
 	}
 
 	public Block getCasingBlock() {

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialCokeOven.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialCokeOven.java
@@ -1,5 +1,6 @@
 package gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi;
 
+import gregtech.api.util.GT_Utility;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
 
@@ -99,7 +100,7 @@ extends GregtechMeta_MultiBlockBase {
 
 	@Override
 	public boolean checkRecipe(final ItemStack aStack) {
-		return checkRecipeGeneric(this.mLevel * 12, (100-(Utils.calculateVoltageTier(this.getMaxInputVoltage())*4)), 0);
+		return checkRecipeGeneric(this.mLevel * 12, (100-(GT_Utility.getTier(this.getMaxInputVoltage())*4)), 0);
 	}
 
 	@Override

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialCuttingMachine.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialCuttingMachine.java
@@ -13,7 +13,7 @@ import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Maintenance;
 import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.util.GT_Recipe;
-
+import gregtech.api.util.GT_Utility;
 import gtPlusPlus.api.objects.Logger;
 import gtPlusPlus.core.block.ModBlocks;
 import gtPlusPlus.core.lib.CORE;
@@ -84,7 +84,7 @@ extends GregtechMeta_MultiBlockBase {
 
 	@Override
 	public boolean checkRecipe(final ItemStack aStack) {
-		return checkRecipeGeneric((4*Utils.calculateVoltageTier(this.getMaxInputVoltage())), 75, 200);
+		return checkRecipeGeneric((4* GT_Utility.getTier(this.getMaxInputVoltage())), 75, 200);
 	}
 
 	@Override

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialElectrolyzer.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialElectrolyzer.java
@@ -11,7 +11,7 @@ import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.util.GT_Recipe;
-
+import gregtech.api.util.GT_Utility;
 import gtPlusPlus.core.block.ModBlocks;
 import gtPlusPlus.core.lib.CORE;
 import gtPlusPlus.core.util.Utils;
@@ -83,7 +83,7 @@ extends GregtechMeta_MultiBlockBase {
 
 	@Override
 	public boolean checkRecipe(final ItemStack aStack) {
-		return checkRecipeGeneric(2*Utils.calculateVoltageTier(this.getMaxInputVoltage()), 90, 180);
+		return checkRecipeGeneric(2* GT_Utility.getTier(this.getMaxInputVoltage()), 90, 180);
 	}
 
 	@Override

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialExtruder.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialExtruder.java
@@ -2,6 +2,7 @@ package gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi;
 
 import java.util.ArrayList;
 
+import gregtech.api.util.GT_Utility;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
@@ -112,7 +113,7 @@ extends GregtechMeta_MultiBlockBase {
 				inputs[slot++] = g;
 			}			
 			if (inputs.length > 0) {				
-				int para = (4*Utils.calculateVoltageTier(this.getMaxInputVoltage()));
+				int para = (4* GT_Utility.getTier(this.getMaxInputVoltage()));
 				Logger.WARNING("Recipe. ["+inputs.length+"]["+para+"]");				
 				if (checkRecipeGeneric(inputs, new FluidStack[]{}, para, 100, 250, 10000)) {
 					Logger.WARNING("Recipe 2.");

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialMultiMachine.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialMultiMachine.java
@@ -125,11 +125,11 @@ extends GregtechMeta_MultiBlockBase {
 
 			//Logger.INFO("4");
 			if (checkRecipeGeneric(tBusItems.toArray(new ItemStack[]{}), properArray,
-					(2*Utils.calculateVoltageTier(this.getMaxInputVoltage())), 80, 250, 10000)) return true;
+					(2*GT_Utility.getTier(this.getMaxInputVoltage())), 80, 250, 10000)) return true;
 		}
 		return false;
 		
-		//return checkRecipeGeneric(2*Utils.calculateVoltageTier(this.getMaxInputVoltage()), 90, 180);
+		//return checkRecipeGeneric(2*GT_Utility.getTier(this.getMaxInputVoltage()), 90, 180);
 	}
 
 	@Override

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialPlatePress.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialPlatePress.java
@@ -2,6 +2,7 @@ package gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi;
 
 import java.util.ArrayList;
 
+import gregtech.api.util.GT_Utility;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
@@ -104,7 +105,7 @@ extends GregtechMeta_MultiBlockBase {
 			}
 
 			if (checkRecipeGeneric(tBusItems.toArray(new ItemStack[]{}), new FluidStack[]{},
-					(4*Utils.calculateVoltageTier(this.getMaxInputVoltage())), 100, 500, 10000)) return true;
+					(4* GT_Utility.getTier(this.getMaxInputVoltage())), 100, 500, 10000)) return true;
 		}
 		return false;
 	}

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialSifter.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialSifter.java
@@ -15,7 +15,7 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_OutputBus;
 import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.util.GT_Recipe;
-
+import gregtech.api.util.GT_Utility;
 import gtPlusPlus.api.objects.Logger;
 import gtPlusPlus.core.block.ModBlocks;
 import gtPlusPlus.core.lib.CORE;
@@ -114,7 +114,7 @@ extends GregtechMeta_MultiBlockBase {
 
 	@Override
 	public boolean checkRecipe(final ItemStack aStack) {
-		return checkRecipeGeneric((4*Utils.calculateVoltageTier(this.getMaxInputVoltage())), 75, 400, 8800);
+		return checkRecipeGeneric((4* GT_Utility.getTier(this.getMaxInputVoltage())), 75, 400, 8800);
 	}
 
 	@Override

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialThermalCentrifuge.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialThermalCentrifuge.java
@@ -12,7 +12,7 @@ import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.util.GT_Recipe;
-
+import gregtech.api.util.GT_Utility;
 import gtPlusPlus.api.objects.Logger;
 import gtPlusPlus.core.block.ModBlocks;
 import gtPlusPlus.core.lib.CORE;
@@ -86,7 +86,7 @@ extends GregtechMeta_MultiBlockBase {
 
 	@Override
 	public boolean checkRecipe(final ItemStack aStack) {
-		return checkRecipeGeneric((8*Utils.calculateVoltageTier(this.getMaxInputVoltage())), 80, 150);
+		return checkRecipeGeneric((8* GT_Utility.getTier(this.getMaxInputVoltage())), 80, 150);
 	}
 
 	@Override

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialWashPlant.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialWashPlant.java
@@ -13,7 +13,7 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Output;
 import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.util.GT_Recipe;
-
+import gregtech.api.util.GT_Utility;
 import gtPlusPlus.api.objects.Logger;
 import gtPlusPlus.core.block.ModBlocks;
 import gtPlusPlus.core.lib.CORE;
@@ -97,7 +97,7 @@ extends GregtechMeta_MultiBlockBase {
 	@Override
 	public boolean checkRecipe(final ItemStack aStack) {
 		if (checkForWater()) {
-			if (checkRecipeGeneric((4*Utils.calculateVoltageTier(this.getMaxInputVoltage())), 100, 400)) {
+			if (checkRecipeGeneric((4* GT_Utility.getTier(this.getMaxInputVoltage())), 100, 400)) {
 				return addSludge();
 			}
 		}

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialWireMill.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_IndustrialWireMill.java
@@ -14,7 +14,7 @@ import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Maintenance;
 import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.util.GT_Recipe;
-
+import gregtech.api.util.GT_Utility;
 import gtPlusPlus.api.objects.Logger;
 import gtPlusPlus.core.block.ModBlocks;
 import gtPlusPlus.core.lib.CORE;
@@ -89,7 +89,7 @@ extends GregtechMeta_MultiBlockBase {
 
 	@Override
 	public boolean checkRecipe(final ItemStack aStack) {
-		return checkRecipeGeneric((4*Utils.calculateVoltageTier(this.getMaxInputVoltage())), 75, 200);
+		return checkRecipeGeneric((4* GT_Utility.getTier(this.getMaxInputVoltage())), 75, 200);
 	}
 
 	@Override

--- a/src/Java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechConduits.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/registration/gregtech/GregtechConduits.java
@@ -118,7 +118,7 @@ public class GregtechConduits {
 
 	private static void wireFactory(final String Material, final int Voltage, final int ID, final long insulatedLoss, final long uninsulatedLoss, final long Amps, final short[] rgb){
 		final Materials T = Materials.valueOf(Material);
-		int V = Utils.calculateVoltageTier(Voltage);
+		int V = GT_Utility.getTier(Voltage);
 		if (V == -1){
 			Logger.ERROR("Failed to set voltage on "+Material+". Invalid voltage of "+Voltage+"V set.");
 			Logger.ERROR(Material+" has defaulted to 8v.");
@@ -151,7 +151,7 @@ public class GregtechConduits {
 	}
 
 	private static void customWireFactory(final Material Material, final int Voltage, final int ID, final long insulatedLoss, final long uninsulatedLoss, final long Amps){
-		int V = Utils.calculateVoltageTier(Voltage);
+		int V = GT_Utility.getTier(Voltage);
 		if (V == -1){
 			Logger.ERROR("Failed to set voltage on "+Material+". Invalid voltage of "+Voltage+"V set.");
 			Logger.ERROR(Material+" has defaulted to 8v.");


### PR DESCRIPTION
Fixes issues where `calculateVoltageTier` had some tier voltages wrong, and allows compatibility with voltages above UV (UHV, UEV, etc) added in GregTech.