### PR TITLE
Rewrite Power Substation's running logic

### DIFF
--- a/src/Java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/api/metatileentity/implementations/base/GregtechMeta_MultiBlockBase.java
@@ -526,7 +526,7 @@ GT_MetaTileEntity_MultiBlockBase {
 					(GT_MetaTileEntity_Hatch_OutputBattery) aMetaTileEntity);
 		}
 		if (LoadedMods.TecTech){
-			if (isThisHatchMultiDynamo()) {
+			if (isThisHatchMultiDynamo(aMetaTileEntity)) {
 				Logger.REFLECTION("Found isThisHatchMultiDynamo");
 				updateTexture(aTileEntity, aBaseCasingIndex);
 				return this.mMultiDynamoHatches.add(
@@ -686,19 +686,19 @@ GT_MetaTileEntity_MultiBlockBase {
 		if (aMetaTileEntity == null) {
 			return false;
 		}
-		if (isThisHatchMultiDynamo()) {
+		if (isThisHatchMultiDynamo(aTileEntity)) {
 			updateTexture(aTileEntity, aBaseCasingIndex);
 			return this.mMultiDynamoHatches.add((GT_MetaTileEntity_Hatch) aMetaTileEntity);
 		}
 		return false;
 	}
 
-	public boolean isThisHatchMultiDynamo(){
+	public boolean isThisHatchMultiDynamo(Object aMetaTileEntity){
 		Class mDynamoClass;
 		try {
 			mDynamoClass = Class.forName("com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_Hatch_DynamoMulti");
 			if (mDynamoClass != null){
-				if (mDynamoClass.isInstance(this)){
+				if (mDynamoClass.isInstance(aMetaTileEntity)){
 					return true;
 				}
 			}
@@ -710,7 +710,7 @@ GT_MetaTileEntity_MultiBlockBase {
 	@Override
 	public boolean addDynamoToMachineList(IGregTechTileEntity aTileEntity, int aBaseCasingIndex) {
 		if (LoadedMods.TecTech){
-			if (isThisHatchMultiDynamo()) {
+			if (isThisHatchMultiDynamo(aTileEntity)) {
 				addMultiAmpDynamoToMachineList(aTileEntity, aBaseCasingIndex);
 			}
 

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_PowerSubStationController.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_PowerSubStationController.java
@@ -95,11 +95,6 @@ public class GregtechMetaTileEntity_PowerSubStationController extends GregtechMe
 	}
 
 	@Override
-	public void onConfigLoad(final GT_Config aConfig) {
-		super.onConfigLoad(aConfig);
-	}
-
-	@Override
 	public boolean checkRecipe(final ItemStack aStack) {
 		return (this.mActualStoredEU >= 0);
 	}
@@ -303,36 +298,9 @@ public class GregtechMetaTileEntity_PowerSubStationController extends GregtechMe
 		return tAmount >= 35;
 	}
 
-	public boolean ignoreController(final Block tTileEntity) {
-		if (!controller && (tTileEntity == GregTech_API.sBlockMachines)) {
-			return true;
-		}
-		return false;
-	}
-
-	@Override
-	public boolean isCorrectMachinePart(final ItemStack aStack) {
-		return true;
-	}
-
 	@Override
 	public int getMaxEfficiency(final ItemStack aStack) {
 		return 10000;
-	}
-
-	@Override
-	public int getPollutionPerTick(final ItemStack aStack) {
-		return 0;
-	}
-
-	@Override
-	public int getDamageToComponent(final ItemStack aStack) {
-		return 0;
-	}
-
-	@Override
-	public int getAmountOfOutputs() {
-		return 1;
 	}
 
 	@Override
@@ -384,11 +352,6 @@ public class GregtechMetaTileEntity_PowerSubStationController extends GregtechMe
 		this.mIsOutputtingPower = aNBT.getBoolean("mIsOutputtingPower");
 
 		super.loadNBTData(aNBT);
-	}
-
-	@Override
-	public int maxProgresstime() {
-		return super.maxProgresstime();
 	}
 
 	@Override
@@ -456,11 +419,6 @@ public class GregtechMetaTileEntity_PowerSubStationController extends GregtechMe
 			}
 		}		
 		super.onPostTick(aBaseMetaTileEntity, aTick);
-	}
-
-	@Override
-	public boolean onRunningTick(ItemStack aStack) {
-		return super.onRunningTick(aStack);
 	}
 
 	@Override

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_PowerSubStationController.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_PowerSubStationController.java
@@ -3,6 +3,7 @@ package gtPlusPlus.xmod.gregtech.common.tileentities.machines.multi;
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
+import gregtech.api.util.GT_Utility;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
@@ -33,6 +34,7 @@ import gtPlusPlus.xmod.gregtech.api.gui.GUI_MultiMachine;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_InputBattery;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_OutputBattery;
 import gtPlusPlus.xmod.gregtech.api.metatileentity.implementations.base.GregtechMeta_MultiBlockBase;
+import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.common.util.ForgeDirection;
 
 public class GregtechMetaTileEntity_PowerSubStationController extends GregtechMeta_MultiBlockBase {
@@ -476,7 +478,6 @@ public class GregtechMetaTileEntity_PowerSubStationController extends GregtechMe
 
 	@Override
 	public String[] getInfoData() {
-
 		long seconds = (this.mTotalRunTime/20);
 
 		int weeks = (int) (TimeUnit.SECONDS.toDays(seconds) / 7);
@@ -485,14 +486,22 @@ public class GregtechMetaTileEntity_PowerSubStationController extends GregtechMe
 		long minutes = TimeUnit.SECONDS.toMinutes(seconds) - (TimeUnit.SECONDS.toHours(seconds) * 60);
 		long second = TimeUnit.SECONDS.toSeconds(seconds) - (TimeUnit.SECONDS.toMinutes(seconds) *60);
 
+		String mode;
+		if (mIsOutputtingPower) {
+			mode = EnumChatFormatting.GOLD + "Output" + EnumChatFormatting.RESET;
+		} else {
+			mode = EnumChatFormatting.BLUE + "Input" + EnumChatFormatting.RESET;
+		}
 		return new String[]{
 				"Ergon Energy - District Sub-Station",
-				"Controller Mode: "+(mIsOutputtingPower ? "Output" : "Input"),
-				"EU Required: "+this.mAverageEuUsage+"EU/t",
+				"Stored EU:" + EnumChatFormatting.GREEN + GT_Utility.formatNumbers(this.getEUVar()) + EnumChatFormatting.RESET,
+				"Capacity: " + EnumChatFormatting.YELLOW + GT_Utility.formatNumbers(this.maxEUStore()) + EnumChatFormatting.RESET,
+				"Running Costs: " + EnumChatFormatting.RED + GT_Utility.formatNumbers(this.mAverageEuUsage) + EnumChatFormatting.RESET + " EU/t",
+				"Controller Mode: " + mode,
 				"Stats for Nerds",
-				"Total Input: "+this.mTotalEnergyAdded+"EU",
-				"Total Output: "+this.mTotalEnergyConsumed+"EU",
-				"Total Wasted: "+this.mTotalEnergyLost+"EU",
+				"Total Input: " + EnumChatFormatting.BLUE + GT_Utility.formatNumbers(this.mTotalEnergyAdded) + EnumChatFormatting.RESET + " EU",
+				"Total Output: " + EnumChatFormatting.GOLD + GT_Utility.formatNumbers(this.mTotalEnergyConsumed) + EnumChatFormatting.RESET + " EU",
+				"Total Costs: " + EnumChatFormatting.RED + GT_Utility.formatNumbers(this.mTotalEnergyLost) + EnumChatFormatting.RESET + " EU",
 
 				"Total Time Since Built: ",
 				""+weeks+" Weeks.",
@@ -500,7 +509,8 @@ public class GregtechMetaTileEntity_PowerSubStationController extends GregtechMe
 				""+hours+" Hours.",
 				""+minutes+" Minutes.",
 				""+second+" Seconds.",
-				"Total Time in ticks: "+this.mTotalRunTime};
+				"Total Time in ticks: "+this.mTotalRunTime
+		};
 
 	};
 

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_PowerSubStationController.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_PowerSubStationController.java
@@ -126,47 +126,46 @@ public class GregtechMetaTileEntity_PowerSubStationController extends GregtechMe
 						// Station Floor & Roof (Inner 5x5) + Mufflers, Dynamos and Fluid outputs.
 						if ((h == 0 || h == 3) || (h == 2 || h == 1)) {
 
-							if (h == 2 || h == 1){						
+							if (h == 2 || h == 1) {
 								//If not a hatch, continue, else add hatch and continue.
 								if (aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j) != ModBlocks.blockCasings2Misc) {
 									Logger.INFO("Station Casing(s) Missing from one of the top layers inner 3x3.");
-									Logger.INFO("Instead, found "+aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j).getLocalizedName());
+									Logger.INFO("Instead, found " + aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j).getLocalizedName());
 									return false;
 								}
 								if (aBaseMetaTileEntity.getMetaIDOffset(xDir + i, h, zDir + j) != 7) {
-									Logger.INFO("Station Casing(s) Missing from one of the top layers inner 3x3. Wrong Meta for Casing. Found:"+aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j).getLocalizedName()+" with meta:"+aBaseMetaTileEntity.getMetaIDOffset(xDir + i, h, zDir + j));
+									Logger.INFO("Station Casing(s) Missing from one of the top layers inner 3x3. Wrong Meta for Casing. Found:" + aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j).getLocalizedName() + " with meta:" + aBaseMetaTileEntity.getMetaIDOffset(xDir + i, h, zDir + j));
 									return false;
 								}
-							}
-							else {
-								if (h==0){
+							} else {
+								if (h == 0) {
 									if (!this.addToMachineList(tTileEntity, TAE.GTPP_INDEX(24))) {
 										if (aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j) != ModBlocks.blockCasings2Misc) {
 											Logger.INFO("Station Casing(s) Missing from one of the bottom layers inner 3x3.");
-											Logger.INFO("Instead, found "+aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j).getLocalizedName());
+											Logger.INFO("Instead, found " + aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j).getLocalizedName());
 											return false;
 										}
 										if (aBaseMetaTileEntity.getMetaIDOffset(xDir + i, h, zDir + j) != 8) {
-											Logger.INFO("Station Casing(s) Missing from one of the bottom layers inner 3x3. Wrong Meta for Casing. Found:"+aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j).getLocalizedName()+" with meta:"+aBaseMetaTileEntity.getMetaIDOffset(xDir + i, h, zDir + j));
+											Logger.INFO("Station Casing(s) Missing from one of the bottom layers inner 3x3. Wrong Meta for Casing. Found:" + aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j).getLocalizedName() + " with meta:" + aBaseMetaTileEntity.getMetaIDOffset(xDir + i, h, zDir + j));
 											return false;
 										}
 										tAmount++;
 									}
 								}
-								if (h==3){
+								if (h == 3) {
 									if (!this.addToMachineList(tTileEntity, TAE.GTPP_INDEX(24))) {
 										if (aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j) != ModBlocks.blockCasings2Misc) {
 											Logger.INFO("Station Casing(s) Missing from one of the top layers inner 3x3.");
-											Logger.INFO("Instead, found "+aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j).getLocalizedName());
+											Logger.INFO("Instead, found " + aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j).getLocalizedName());
 											return false;
 										}
 										if (aBaseMetaTileEntity.getMetaIDOffset(xDir + i, h, zDir + j) != 8) {
-											Logger.INFO("Station Casing(s) Missing from one of the top layers inner 3x3. Wrong Meta for Casing. Found:"+aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j).getLocalizedName()+" with meta:"+aBaseMetaTileEntity.getMetaIDOffset(xDir + i, h, zDir + j));
+											Logger.INFO("Station Casing(s) Missing from one of the top layers inner 3x3. Wrong Meta for Casing. Found:" + aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j).getLocalizedName() + " with meta:" + aBaseMetaTileEntity.getMetaIDOffset(xDir + i, h, zDir + j));
 											return false;
 										}
 										tAmount++;
 									}
-								}								
+								}
 							}
 						}
 					}
@@ -176,46 +175,44 @@ public class GregtechMetaTileEntity_PowerSubStationController extends GregtechMe
 
 						//Deal with all 4 sides (Station walls)
 						if ((h == 1) || (h == 2) || (h == 3)) {
-							if (h == 3){
+							if (h == 3) {
 								if (!this.addToMachineList(tTileEntity, TAE.GTPP_INDEX(24))) {
 									if (aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j) != ModBlocks.blockCasings2Misc) {
 										Logger.INFO("Station Casings Missing from somewhere in the top layer edge. 3");
-										Logger.INFO("Instead, found "+aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j).getLocalizedName());
+										Logger.INFO("Instead, found " + aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j).getLocalizedName());
 										return false;
 									}
 									if (aBaseMetaTileEntity.getMetaIDOffset(xDir + i, h, zDir + j) != 8) {
 										Logger.INFO("Station Casings Missing from somewhere in the top layer edge. 3");
-										Logger.INFO("Instead, found "+aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j).getLocalizedName());
+										Logger.INFO("Instead, found " + aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j).getLocalizedName());
 										return false;
 									}
 									tAmount++;
 								}
-							}
-							else if (h == 2){
+							} else if (h == 2) {
 								if (!this.addToMachineList(tTileEntity, TAE.GTPP_INDEX(24))) {
 									if (aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j) != ModBlocks.blockCasings2Misc) {
 										Logger.INFO("Station Casings Missing from somewhere in the top layer edge. 2");
-										Logger.INFO("Instead, found "+aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j).getLocalizedName());
+										Logger.INFO("Instead, found " + aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j).getLocalizedName());
 										return false;
 									}
 									if (aBaseMetaTileEntity.getMetaIDOffset(xDir + i, h, zDir + j) != 8) {
 										Logger.INFO("Station Casings Missing from somewhere in the top layer edge. 2");
-										Logger.INFO("Instead, found "+aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j).getLocalizedName());
+										Logger.INFO("Instead, found " + aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j).getLocalizedName());
 										return false;
 									}
 									tAmount++;
 								}
-							}
-							else {
+							} else {
 								if (!this.addToMachineList(tTileEntity, TAE.GTPP_INDEX(24))) {
 									if (aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j) != ModBlocks.blockCasings2Misc) {
 										Logger.INFO("Station Casings Missing from somewhere in the second layer. 1");
-										Logger.INFO("Instead, found "+aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j).getLocalizedName());
+										Logger.INFO("Instead, found " + aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j).getLocalizedName());
 										return false;
 									}
 									if (aBaseMetaTileEntity.getMetaIDOffset(xDir + i, h, zDir + j) != 8) {
 										Logger.INFO("Station Casings Missing from somewhere in the second layer. 1");
-										Logger.INFO("Instead, found "+aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j).getLocalizedName());
+										Logger.INFO("Instead, found " + aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j).getLocalizedName());
 										return false;
 									}
 									tAmount++;
@@ -230,18 +227,17 @@ public class GregtechMetaTileEntity_PowerSubStationController extends GregtechMe
 
 									if (aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j) != ModBlocks.blockCasings2Misc) {
 										Logger.INFO("Station Casing(s) Missing from one of the edges on the top layer.");
-										Logger.INFO("Instead, found "+aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j).getLocalizedName());
+										Logger.INFO("Instead, found " + aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j).getLocalizedName());
 										return false;
 									}
 									if (aBaseMetaTileEntity.getMetaIDOffset(xDir + i, h, zDir + j) != 8) {
-										Logger.INFO("Station Casing(s) Missing from one of the edges on the top layer. "+h);
-										Logger.INFO("Instead, found "+aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j).getLocalizedName());
-										if (h ==0){
-											if (tTileEntity instanceof GregtechMetaTileEntity_PowerSubStationController){
+										Logger.INFO("Station Casing(s) Missing from one of the edges on the top layer. " + h);
+										Logger.INFO("Instead, found " + aBaseMetaTileEntity.getBlockOffset(xDir + i, h, zDir + j).getLocalizedName());
+										if (h == 0) {
+											if (tTileEntity instanceof GregtechMetaTileEntity_PowerSubStationController) {
 
 											}
-										}
-										else {
+										} else {
 											return false;
 										}
 									}
@@ -253,30 +249,30 @@ public class GregtechMetaTileEntity_PowerSubStationController extends GregtechMe
 				}
 			}
 		}
-		
+
 		/**
 		 * TecTech Support, this allows adding Multi-Amp dynamos.
 		 */
-		if (this.mDynamoHatches.size() > 0){
-			for (GT_MetaTileEntity_Hatch_Dynamo o : this.mDynamoHatches){
+		if (this.mDynamoHatches.size() > 0) {
+			for (GT_MetaTileEntity_Hatch_Dynamo o : this.mDynamoHatches) {
 				mAllDynamoHatches.add(o);
 			}
 		}
-		if (LoadedMods.TecTech && this.mMultiDynamoHatches.size() > 0){
-			for (GT_MetaTileEntity_Hatch o : this.mMultiDynamoHatches){
+		if (LoadedMods.TecTech && this.mMultiDynamoHatches.size() > 0) {
+			for (GT_MetaTileEntity_Hatch o : this.mMultiDynamoHatches) {
 				mAllDynamoHatches.add(o);
 			}
-		}		
-		
-		
+		}
+
+
 		if ((this.mMaintenanceHatches.size() != 1) || (this.mEnergyHatches.size() < 1)
 				|| (this.mAllDynamoHatches.size() < 1)) {
 			Logger.INFO("Returned False 3");
-			Logger.INFO("Charge Buses: "+this.mChargeHatches.size()+" | expected: >= 1 | "+(this.mChargeHatches.size() >= 1));
-			Logger.INFO("Discharge Buses: "+this.mDischargeHatches.size()+" | expected: >= 1 | "+(this.mDischargeHatches.size() >= 1));
-			Logger.INFO("Energy Hatches: "+this.mEnergyHatches.size()+" | expected: >= 1 | "+(this.mEnergyHatches.size() < 1));
-			Logger.INFO("Dynamo Hatches: "+this.mAllDynamoHatches.size()+" | expected: >= 1 | "+(this.mAllDynamoHatches.size() < 1));
-			Logger.INFO("Maint. Hatches: "+this.mMaintenanceHatches.size()+" | expected: 1 | "+(this.mMaintenanceHatches.size() != 1));
+			Logger.INFO("Charge Buses: " + this.mChargeHatches.size() + " | expected: >= 1 | " + (this.mChargeHatches.size() >= 1));
+			Logger.INFO("Discharge Buses: " + this.mDischargeHatches.size() + " | expected: >= 1 | " + (this.mDischargeHatches.size() >= 1));
+			Logger.INFO("Energy Hatches: " + this.mEnergyHatches.size() + " | expected: >= 1 | " + (this.mEnergyHatches.size() < 1));
+			Logger.INFO("Dynamo Hatches: " + this.mAllDynamoHatches.size() + " | expected: >= 1 | " + (this.mAllDynamoHatches.size() < 1));
+			Logger.INFO("Maint. Hatches: " + this.mMaintenanceHatches.size() + " | expected: 1 | " + (this.mMaintenanceHatches.size() != 1));
 			return false;
 		}
 
@@ -291,11 +287,13 @@ public class GregtechMetaTileEntity_PowerSubStationController extends GregtechMe
 			tempAvg += re.getOutputTier();
 			hatchCount++;
 		}
-		if (hatchCount > 0){
-			this.mAverageEuUsage = (tempAvg/hatchCount);
+		if (hatchCount > 0) {
+			this.mAverageEuUsage = (tempAvg / hatchCount);
+		} else {
+			this.mAverageEuUsage = 0;
 		}
 
-		Logger.INFO("Structure Built? "+""+tAmount+" | "+(tAmount>=35));
+		Logger.INFO("Structure Built? " + "" + tAmount + " | " + (tAmount >= 35));
 
 		return tAmount >= 35;
 	}
@@ -346,7 +344,7 @@ public class GregtechMetaTileEntity_PowerSubStationController extends GregtechMe
 		this.mTotalEnergyLost = aNBT.getLong("mTotalEnergyLost");
 		this.mTotalEnergyConsumed = aNBT.getLong("mTotalEnergyConsumed");
 		this.mTotalRunTime = aNBT.getLong("mTotalRunTime");
-		
+
 		this.mIsOutputtingPower = aNBT.getBoolean("mIsOutputtingPower");
 
 		super.loadNBTData(aNBT);

--- a/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_PowerSubStationController.java
+++ b/src/Java/gtPlusPlus/xmod/gregtech/common/tileentities/machines/multi/GregtechMetaTileEntity_PowerSubStationController.java
@@ -96,7 +96,7 @@ public class GregtechMetaTileEntity_PowerSubStationController extends GregtechMe
 
 	@Override
 	public boolean checkRecipe(final ItemStack aStack) {
-		return (this.mActualStoredEU >= 0);
+		return true;
 	}
 
 	@Override
@@ -316,15 +316,12 @@ public class GregtechMetaTileEntity_PowerSubStationController extends GregtechMe
 	//NBT Power Storage handling
 	long mPowerStorageBuffer = 0;
 	int mPowerStorageMultiplier = 32;
-	long mActualStoredEU = 0;
-
 
 	//mTotalEnergyAdded
 	@Override
 	public void saveNBTData(NBTTagCompound aNBT) {
 		aNBT.setLong("mPowerStorageBuffer", this.mPowerStorageBuffer);
 		aNBT.setInteger("mPowerStorageMultiplier", this.mPowerStorageMultiplier);
-		aNBT.setLong("mActualStoredEU", this.mActualStoredEU);
 		aNBT.setInteger("mAverageEuUsage", this.mAverageEuUsage);
 
 		//Usage Stats
@@ -340,7 +337,6 @@ public class GregtechMetaTileEntity_PowerSubStationController extends GregtechMe
 	public void loadNBTData(NBTTagCompound aNBT) {
 		this.mPowerStorageBuffer = aNBT.getLong("mPowerStorageBuffer");
 		this.mPowerStorageMultiplier = aNBT.getInteger("mPowerStorageMultiplier");
-		this.mActualStoredEU = aNBT.getLong("mActualStoredEU");
 		this.mAverageEuUsage = aNBT.getInteger("mAverageEuUsage");
 
 		//Usage Stats
@@ -356,17 +352,12 @@ public class GregtechMetaTileEntity_PowerSubStationController extends GregtechMe
 
 	@Override
 	public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
-		this.mActualStoredEU = this.getEUVar();
-		
-		if (this.mActualStoredEU < 0){
-			this.mActualStoredEU = 0;
-		}
 		if (this.getEUVar() < 0){
 			this.setEUVar(0);
 		}
 
 		//Handle Progress Time
-		if (this.mActualStoredEU >= 0 && this.getBaseMetaTileEntity().isAllowedToWork()){
+		if (this.getBaseMetaTileEntity().isAllowedToWork()){
 			this.mProgresstime = 20;
 			this.mMaxProgresstime = 40;	
 			//Use 10% of average EU determined by adding in/output voltage of all hatches and averaging.
@@ -384,7 +375,7 @@ public class GregtechMetaTileEntity_PowerSubStationController extends GregtechMe
 		if (this.getBaseMetaTileEntity().isAllowedToWork()){
 
 			//Input Power
-			if (this.mActualStoredEU < this.maxEUStore()){
+			if (this.getEUVar() < this.maxEUStore()){
 				if (this.getBaseMetaTileEntity().isAllowedToWork()){
 					this.getBaseMetaTileEntity().enableWorking();
 				}
@@ -414,9 +405,8 @@ public class GregtechMetaTileEntity_PowerSubStationController extends GregtechMe
 			}
 
 			//Output Power
-			if (this.mActualStoredEU > 0){
-				addEnergyOutput(1);
-			}
+			addEnergyOutput(1);
+
 		}		
 		super.onPostTick(aBaseMetaTileEntity, aTick);
 	}
@@ -428,17 +418,13 @@ public class GregtechMetaTileEntity_PowerSubStationController extends GregtechMe
 		long nStoredPower = this.getEUVar();
 		for (GT_MetaTileEntity_Hatch_OutputBattery tHatch : this.mDischargeHatches) {
 			if ((isValidMetaTileEntity(tHatch))	&& (tHatch.getBaseMetaTileEntity().decreaseStoredEnergyUnits(aEU, false))){
-				if (this.mActualStoredEU<this.maxEUStore()){
 
-				}
 				Logger.INFO("Draining Discharge Hatch #2");
 			}
 		}
 		for (GT_MetaTileEntity_Hatch_Energy tHatch : this.mEnergyHatches) {
 			if ((isValidMetaTileEntity(tHatch))	&& (tHatch.getBaseMetaTileEntity().decreaseStoredEnergyUnits(aEU, false))){
-				if (this.mActualStoredEU<this.maxEUStore()){
-					//this.getBaseMetaTileEntity().increaseStoredEnergyUnits(aEU, false);
-				}
+
 			}
 		}		
 		long nNewStoredPower = this.getEUVar();


### PR DESCRIPTION
Remove a few dozen lines of dead code.

Add pretty colors to the scanner and info panel readouts. Add the energy
storage and capacity to the top of the readout. Solves an issue where 
the energy storage was not displayed on info panels.

Fix an issue in the base class that prevented TecTech multi-amp dynamos 
from being identified.

Implement logic in `onRunningTick` instead of `onPostTick`, allowing
the base maintenance/repair logic to take effect. Solves an issue where
the machine must be built with a maintenance hatch which has no effect 
when repaired.

Rewrite hatch draining/filling to consider the station's available
energy and the hatch's capacity and throughput, including its amperage.
Energy hatches now correctly supply 2A to the station, and multi-amp
dynamos output the proper number of amps. Solves an issue where the 
substation acted as a creative energy buffer.

Rewrite running costs to consider the actual average voltage instead of
the voltage tier, and increase running costs according to maintenance
problems. Running cost % is now configurable via a constant ENERGY_TAX,
currently 2%. Running costs deliberately ignore hatch amperage to make
multi-amp hatches more appealing. Solves an issue where the running costs
were always a single-digit amount.

Also clear the dynamo hatch lists on each machine check to prevent them
filling up with duplicate hatches.