### PR TITLE
Remove mOreDictCache and mDustCache from ItemUtils

### DIFF
--- a/src/Java/gtPlusPlus/core/util/minecraft/ItemUtils.java
+++ b/src/Java/gtPlusPlus/core/util/minecraft/ItemUtils.java
@@ -265,42 +265,13 @@ public class ItemUtils {
 		if (oredictName.toLowerCase().contains("vanadiumsteel")){
 			mTemp = oredictName.replace("VanadiumSteel", "StainlessSteel");
 		}			
-		//Use Cache		
-		if (mOreDictCache.containsKey(mTemp) && mOreDictCache.get(mTemp) != null && mOreDictCache.get(mTemp).getItem() != ModItems.AAA_Broken) {
-			//Logger.INFO("[ODC] Returning mOreDictCache value.");
-			return getCachedValue(mTemp, amount);
+		final ArrayList<ItemStack> oreDictList = OreDictionary.getOres(mTemp);
+		if (!oreDictList.isEmpty()){
+			final ItemStack returnValue = oreDictList.get(0).copy();
+			returnValue.stackSize = amount;
+			return returnValue;
 		}
-		else if (mDustCache.containsKey(oredictName) && mDustCache.get(mTemp) != null && mOreDictCache.get(mTemp).getItem() != ModItems.AAA_Broken) {
-			//Logger.INFO("[ODC] Returning mDustCache value.");
-			return getSimpleStack(mDustCache.get(oredictName), amount);
-		}
-		else {
-			//Logger.INFO("[ODC] Setting mOreDictCache value.");
-			final ArrayList<ItemStack> oreDictList = OreDictionary.getOres(mTemp);
-			if (!oreDictList.isEmpty()){
-				final ItemStack returnValue = oreDictList.get(0).copy();
-				returnValue.stackSize = amount;
-				if (returnValue.getItem() != ModItems.AAA_Broken) {
-					setCachedValue(mTemp, returnValue);
-				}
-				//Logger.INFO("[ODC] Setting and Returning mOreDictCache value.");
-				return returnValue;
-			}
-			setCachedValue(oredictName, getSimpleStack(ModItems.AAA_Broken));
-			//Logger.INFO("[ODC] Returning AAA_Broken.");
-			return getSimpleStack(ModItems.AAA_Broken, amount);
-		}
-		
-	}
-
-	private static Map<String, ItemStack> mOreDictCache = new HashMap();
-
-	private static ItemStack getCachedValue(String string, int amount) {
-		return getSimpleStack(mOreDictCache.get(string), amount);
-	}
-
-	private static void setCachedValue(String string, ItemStack stack) {
-		mOreDictCache.put(string, stack);
+		return getSimpleStack(ModItems.AAA_Broken, amount);
 	}
 
 	public static ItemStack getItemStackOfAmountFromOreDictNoBroken(final String oredictName, final int amount){
@@ -312,15 +283,6 @@ public class ItemUtils {
 			Logger.WARNING("Looking up: "+oredictName+" - from method: "+ReflectionUtils.getMethodName(5));
 		}	
 		
-		//Use Cache
-		if (mDustCache.containsKey(oredictName)) {
-			return getSimpleStack(mDustCache.get(oredictName), amount);
-		}	
-		if (mOreDictCache.containsKey(oredictName)) {
-			return getCachedValue(oredictName, amount);
-		}
-		
-
 		try{
 
 			//Adds a check to grab dusts using GT methodology if possible.
@@ -330,7 +292,6 @@ public class ItemUtils {
 				final Materials m = Materials.get(MaterialName);
 				returnValue = getGregtechDust(m, amount);
 				if (returnValue != null){
-					setCachedValue(oredictName, returnValue);
 					return returnValue;
 				}
 			}
@@ -339,7 +300,6 @@ public class ItemUtils {
 				returnValue = getItemStackOfAmountFromOreDict(oredictName, amount);
 				if (returnValue != null){
 					if ((returnValue.getItem().getClass() != ModItems.AAA_Broken.getClass()) || (returnValue.getItem() != ModItems.AAA_Broken)){
-						setCachedValue(oredictName, returnValue);
 						return returnValue.copy();
 					}
 				}
@@ -690,15 +650,8 @@ public class ItemUtils {
 		return getModId(key.getItem());
 	}
 
-	private static Map<String, ItemStack> mDustCache = new HashMap<String, ItemStack>();
-	
 	//Take 2 - GT/GT++ Dusts
 	public static ItemStack getGregtechDust(final String oredictName, final int amount){
-		
-		if (mDustCache.containsKey(oredictName)) {
-			return getSimpleStack(mDustCache.get(oredictName), amount);
-		}
-		
 		final ArrayList<ItemStack> oreDictList = OreDictionary.getOres(oredictName);
 		if (!oreDictList.isEmpty()){
 			ItemStack returnvalue;
@@ -706,7 +659,6 @@ public class ItemUtils {
 				final String modid = getModId(oreDictList.get(xrc).getItem());
 				if (modid != null && (modid.equals("gregtech") || modid.equals(CORE.MODID))){
 					returnvalue = oreDictList.get(xrc).copy();
-					mDustCache.put(oredictName, returnvalue);
 					returnvalue.stackSize = amount;
 					return returnvalue;
 				}
@@ -717,11 +669,6 @@ public class ItemUtils {
 
 	//Anything But Tinkers Dust
 	public static ItemStack getNonTinkersDust(final String oredictName, final int amount){
-		
-		if (mDustCache.containsKey(oredictName)) {
-			return getSimpleStack(mDustCache.get(oredictName), amount);
-		}
-		
 		final ArrayList<ItemStack> oreDictList = OreDictionary.getOres(oredictName);
 		if (!oreDictList.isEmpty()){
 			ItemStack returnvalue;
@@ -729,7 +676,6 @@ public class ItemUtils {
 				final String modid = getModId(oreDictList.get(xrc).getItem());
 				if (modid  != null && !modid.equals("tconstruct")){
 					returnvalue = oreDictList.get(xrc).copy();
-					mDustCache.put(oredictName, returnvalue);
 					returnvalue.stackSize = amount;
 					return returnvalue;
 				}
@@ -738,6 +684,7 @@ public class ItemUtils {
 		//If only Tinkers dust exists, bow down and just use it.
 		return getItemStackOfAmountFromOreDictNoBroken(oredictName, amount);
 	}
+
 	public static ItemStack getGregtechOreStack(OrePrefixes mPrefix, Materials mMat, int mAmount) {
 
 		String mName = MaterialUtils.getMaterialName(mMat);


### PR DESCRIPTION
It is incorrect to cache ore dict items during initialization, as this
is when items are being added to the ore dict.

Fixes issues where fluid cells weren't being correctly registered as
fluid containers.